### PR TITLE
Add pollinations controller example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # Computer-Control
-Computer-Control
+
+This project demonstrates how to let the [Pollinations AI](https://pollinations.ai)
+service operate your desktop. The script repeatedly sends screenshots of your
+desktop to Pollinations. The model replies with tool calls to run shell
+commands, move the mouse, type text and more. After each action a new screenshot
+is captured and sent back so the model can iterate just like a human.
+
+The interaction uses Pollinations' OpenAI-compatible endpoint. The returned tool
+calls are executed locally via Python using `pyautogui` for GUI operations.
+These actions include launching applications, moving the mouse and typing text
+so the code works across Windows, macOS and Linux provided a GUI environment is
+available.
+
+## Requirements
+
+- Python 3.8+
+- See `requirements.txt` for dependencies
+- Install them with `pip install -r requirements.txt`
+- Linux users may also need the `scrot` package for screenshots
+
+## Usage
+
+Set the `POLLINATIONS_API` environment variable to override the default endpoint
+(`https://text.pollinations.ai/openai`). Optionally specify
+`POLLINATIONS_REFERRER` to identify your app.
+
+Run a goal with up to a number of interaction loops:
+
+```bash
+python computer_control.py "open calculator" --steps 3
+```
+
+The AI may request functions like `open_app` to launch applications. These tool
+calls are executed automatically unless `--dry-run` is used.
+
+Add `--dry-run` to print actions instead of executing them. Pollinations will
+respond with JSON tool calls which are executed sequentially. Each iteration
+captures a fresh screenshot so the AI can correct itself.
+
+**Warning:** Allowing a remote AI to issue commands on your machine can be
+hazardous. Review output carefully or use the `--dry-run` option when testing.
+This example is provided on a best-effort basis and may require tweaking for
+your specific setup.

--- a/computer_control.py
+++ b/computer_control.py
@@ -1,0 +1,63 @@
+"""Run a goal through Pollinations AI to control the computer."""
+from __future__ import annotations
+
+import argparse
+from typing import List, Dict, Any
+
+import controller
+import pollinations_client as client
+
+
+def main(goal: str, steps: int = 5, dry_run: bool = False) -> None:
+    """Send ``goal`` to Pollinations and execute returned actions."""
+    messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": client.SYSTEM_PROMPT}
+    ]
+    screenshot = controller.capture_screen()
+    messages.append(
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": goal},
+                {"type": "image_url", "image_url": {"url": screenshot}},
+            ],
+        }
+    )
+
+    for _ in range(steps):
+        data = client.query_pollinations(messages)
+        choice = data.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            client.execute_tool_calls(tool_calls, dry_run=dry_run)
+        if content := message.get("content"):
+            print(content)
+        messages.append(
+            {
+                "role": "assistant",
+                "content": message.get("content", ""),
+                **({"tool_calls": tool_calls} if tool_calls else {}),
+            }
+        )
+        screenshot = controller.capture_screen()
+        messages.append(
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Updated screen"},
+                    {"type": "image_url", "image_url": {"url": screenshot}},
+                ],
+            }
+        )
+        if not tool_calls:
+            break
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Control the computer with Pollinations AI")
+    parser.add_argument("goal", help="Goal to send to the AI")
+    parser.add_argument("--steps", type=int, default=5, help="Maximum interaction loops")
+    parser.add_argument("--dry-run", action="store_true", help="Print actions instead of executing")
+    args = parser.parse_args()
+    main(args.goal, steps=args.steps, dry_run=args.dry_run)

--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,73 @@
+"""Platform-independent actions executed on behalf of the AI."""
+from __future__ import annotations
+
+import base64
+import io
+import os
+import subprocess
+import sys
+
+
+try:
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully
+    pyautogui = None  # type: ignore
+
+
+class GUIUnavailable(RuntimeError):
+    """Raised when GUI actions are requested but unavailable."""
+
+
+def ensure_gui_available() -> None:
+    if pyautogui is None:
+        raise GUIUnavailable("pyautogui is not available or no GUI environment")
+
+
+def run_shell(command: str) -> None:
+    """Run a shell command on any platform."""
+    subprocess.run(command, shell=True, check=True)
+
+
+def move_mouse(x: int, y: int) -> None:
+    ensure_gui_available()
+    pyautogui.moveTo(x, y)
+
+
+def click(x: int, y: int, button: str = "left") -> None:
+    ensure_gui_available()
+    pyautogui.click(x=x, y=y, button=button)
+
+
+def write_text(text: str) -> None:
+    ensure_gui_available()
+    pyautogui.write(text)
+
+
+def press_key(key: str) -> None:
+    ensure_gui_available()
+    pyautogui.press(key)
+
+
+def open_app(name: str) -> None:
+    """Open an application by name on the current platform."""
+    if os.name == "nt":
+        os.startfile(name)
+    elif sys.platform == "darwin":
+        subprocess.run(["open", "-a", name], check=True)
+    else:
+        subprocess.Popen([name])
+
+
+def create_file(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def capture_screen() -> str:
+    ensure_gui_available()
+    image = pyautogui.screenshot()
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    data = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/png;base64,{data}"

--- a/pollinations_client.py
+++ b/pollinations_client.py
@@ -1,0 +1,164 @@
+"""Client utilities for interacting with the Pollinations API."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Callable, Dict, List
+
+import requests
+
+import controller
+
+POLLINATIONS_API = os.environ.get("POLLINATIONS_API", "https://text.pollinations.ai/openai")
+POLLINATIONS_REFERRER = os.environ.get("POLLINATIONS_REFERRER", "https://example.com")
+
+SYSTEM_PROMPT = (
+    "You control the user's computer via function calls. "
+    "Respond with tool_calls describing actions to reach the objective."
+)
+
+FUNCTIONS_SPEC: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "run_shell",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "move_mouse",
+            "description": "Move the mouse to x,y screen coordinates",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}},
+                "required": ["x", "y"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "click",
+            "description": "Click the mouse at x,y",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                    "button": {
+                        "type": "string",
+                        "enum": ["left", "right", "middle"],
+                        "default": "left",
+                    },
+                },
+                "required": ["x", "y"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_text",
+            "description": "Type text at the keyboard",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "press_key",
+            "description": "Press a keyboard key",
+            "parameters": {
+                "type": "object",
+                "properties": {"key": {"type": "string"}},
+                "required": ["key"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "open_app",
+            "description": "Open an application by name",
+            "parameters": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_file",
+            "description": "Create a file with the given content",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+                "required": ["path", "content"],
+            },
+        },
+    },
+]
+
+ACTION_MAP: Dict[str, Callable[..., None]] = {
+    "run_shell": controller.run_shell,
+    "move_mouse": controller.move_mouse,
+    "click": controller.click,
+    "write_text": controller.write_text,
+    "press_key": controller.press_key,
+    "open_app": controller.open_app,
+    "create_file": controller.create_file,
+}
+
+
+def query_pollinations(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Send ``messages`` to Pollinations and return the JSON response."""
+
+    payload = {
+        "model": "openai",
+        "messages": messages,
+        "tools": FUNCTIONS_SPEC,
+        "tool_choice": "auto",
+    }
+
+    headers = {"Referer": POLLINATIONS_REFERRER}
+    response = requests.post(POLLINATIONS_API, json=payload, headers=headers, timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def execute_tool_calls(tool_calls: List[Dict[str, Any]], dry_run: bool = False) -> None:
+    """Run the tool calls returned by the model."""
+    for call in tool_calls:
+        name = call.get("function", {}).get("name")
+        if not name:
+            continue
+        func = ACTION_MAP.get(name)
+        if not func:
+            continue
+        args = call.get("function", {}).get("arguments", "{}")
+        try:
+            params = json.loads(args) if args else {}
+        except json.JSONDecodeError:
+            print(f"Invalid arguments for {name}: {args}")
+            continue
+        if dry_run:
+            print(f"[DRY-RUN] {name}({params})")
+            continue
+        try:
+            func(**params)
+        except Exception as exc:  # pylint: disable=broad-except
+            print(f"Error executing {name}: {exc}")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.31
+pyautogui>=0.9
+pytest>=8.0
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,35 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from typing import Dict, List
+
+import pollinations_client as client
+
+
+def test_functions_spec_matches_action_map():
+    names_spec = {f["function"]["name"] for f in client.FUNCTIONS_SPEC}
+    names_map = set(client.ACTION_MAP)
+    assert names_spec == names_map
+
+
+def test_execute_tool_calls_dry_run(capsys):
+    calls = [
+        {
+            "function": {
+                "name": "run_shell",
+                "arguments": json.dumps({"command": "echo hello"}),
+            }
+        },
+        {
+            "function": {
+                "name": "open_app",
+                "arguments": json.dumps({"name": "calculator"}),
+            }
+        }
+    ]
+    client.execute_tool_calls(calls, dry_run=True)
+    captured = capsys.readouterr()
+    assert "[DRY-RUN] run_shell" in captured.out
+    assert "[DRY-RUN] open_app" in captured.out
+
+


### PR DESCRIPTION
## Summary
- add `computer_control.py` demonstrating how to call Pollinations AI and run the resulting command
- document usage and requirements in README
- add simple `requirements.txt`
- add cross-platform app launcher

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f74546c84832aa22cfa9306910cad