### PR TITLE
Add pollinations controller example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.mypy_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
 # Computer-Control
-Computer-Control
+
+This project demonstrates how to let the [Pollinations AI](https://pollinations.ai)
+service operate your desktop. The script repeatedly sends screenshots of your
+desktop to Pollinations. The model replies with tool calls to run shell
+commands, move the mouse, type text and more. After each action a new screenshot
+is captured and sent back so the model can iterate just like a human.
+
+The interaction uses Pollinations' OpenAI-compatible endpoint. The returned tool
+calls are executed locally via Python using `pyautogui` for GUI operations.
+These actions include launching applications, moving the mouse and typing text
+so the code works across Windows, macOS and Linux provided a GUI environment is
+available.
+
+## Requirements
+
+- Python 3.8+
+- See `requirements.txt` for dependencies
+- Install them with `pip install -r requirements.txt`
+- Linux systems require the `scrot` package for screenshot functionality. Install
+  it with your package manager, for example:
+  `sudo apt-get install scrot` or `sudo yum install scrot`.
+
+## Quick Start
+
+1. Install the requirements:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run a goal in automatic mode (the script keeps looping until the AI
+   signals it is done or reaches 15 steps):
+
+   ```bash
+   python computer_control.py "open calculator"
+   ```
+
+   Add `--dry-run` to preview the tool calls without actually executing
+   them.
+
+3. Run the automated tests (optional):
+
+   ```bash
+   pytest -q
+   ```
+
+## Usage
+
+Set the `POLLINATIONS_API` environment variable to override the default endpoint
+(`https://text.pollinations.ai/openai`). Optionally specify
+`POLLINATIONS_REFERRER` to identify your app.
+
+Run the script from the repository root with a goal:
+
+```bash
+python computer_control.py "open calculator"
+```
+
+The program automatically loops until the AI reports it is done (up to a
+maximum of 15 steps by default). Use `--max-steps` to override that limit or
+`--steps N` to force an exact number of iterations.
+
+`computer_control.py` lives in the project root, so reference it directly
+or with the full path if running from another directory.
+
+The AI may request functions like `open_app` to launch applications. These tool
+calls are executed automatically unless `--dry-run` is used.
+
+Add `--dry-run` to print actions instead of executing them. Pollinations will
+respond with JSON tool calls which are executed sequentially. Each iteration
+captures a fresh screenshot so the AI can correct itself. If a GUI isn't
+available (for example, on a headless server), the script falls back to a blank
+image in dry‑run mode.
+
+
+The Rich-powered interface displays a progress bar and shows each tool call in
+a highlighted panel.
+
+## Testing
+
+Run the automated test suite after installing the requirements:
+
+```bash
+pytest -q
+```
+
+
+**Warning:** Allowing a remote AI to issue commands on your machine can be
+hazardous. Review output carefully or use the `--dry-run` option when testing.
+This example is provided on a best-effort basis and may require tweaking for
+your specific setup.
+
+This project is released under the terms of the MIT License; see
+the `LICENSE` file for details.

--- a/computer_control.py
+++ b/computer_control.py
@@ -1,0 +1,156 @@
+"""Run a goal through Pollinations AI to control the computer."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import List, Dict, Any, Optional
+import base64
+import io
+from PIL import Image
+from rich.console import Console
+from rich.progress import Progress, BarColumn, TextColumn
+from rich.table import Table
+from rich.panel import Panel
+from rich_argparse import RichHelpFormatter
+
+import controller
+import pollinations_client as client
+
+
+def blank_image() -> str:
+    """Return a tiny base64 PNG used when screenshots fail."""
+    buf = io.BytesIO()
+    Image.new("RGB", (1, 1), color="white").save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+def main(
+    goal: str, steps: Optional[int] = None, max_steps: int = 15, dry_run: bool = False
+) -> None:
+    """Send ``goal`` to Pollinations and execute returned actions."""
+    console = Console()
+    messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": client.SYSTEM_PROMPT}
+    ]
+    try:
+        screenshot = controller.capture_screen()
+    except controller.GUIUnavailable as exc:
+        if dry_run:
+            console.print(f"[yellow]Warning: {exc}; using blank screenshot[/yellow]")
+            screenshot = blank_image()
+        else:
+            raise
+    messages.append(
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": goal},
+                {"type": "image_url", "image_url": {"url": screenshot}},
+            ],
+        }
+    )
+
+    loop_limit = steps if steps is not None else max_steps
+
+    with Progress(
+        TextColumn("Step {task.completed}/{task.total}"),
+        BarColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task("ai", total=loop_limit)
+        start_time = time.perf_counter()
+
+        for i in range(loop_limit):
+            progress.update(task, advance=1)
+            data = client.query_pollinations(messages)
+            choice = data.get("choices", [{}])[0]
+            message = choice.get("message", {})
+            tool_calls = message.get("tool_calls")
+            if tool_calls:
+                for call in tool_calls:
+                    name = call.get("function", {}).get("name")
+                    console.print(
+                        Panel(
+                            f"{name}({call.get('function', {}).get('arguments', '{}')})",
+                            title="Tool Call",
+                            style="cyan",
+                        )
+                    )
+                client.execute_tool_calls(tool_calls, dry_run=dry_run, console=console)
+            if content := message.get("content"):
+                console.print(content)
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": message.get("content", ""),
+                    **({"tool_calls": tool_calls} if tool_calls else {}),
+                }
+            )
+            try:
+                screenshot = controller.capture_screen()
+            except controller.GUIUnavailable as exc:
+                if dry_run:
+                    console.print(
+                        f"[yellow]Warning: {exc}; using blank screenshot[/yellow]"
+                    )
+                    screenshot = blank_image()
+                else:
+                    raise
+            messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Updated screen"},
+                        {"type": "image_url", "image_url": {"url": screenshot}},
+                    ],
+                }
+            )
+            status = Table(box=None)
+            status.add_row("Loop", str(i + 1))
+            status.add_row("Elapsed", f"{time.perf_counter() - start_time:.1f}s")
+            status.add_row("Mode", "dry-run" if dry_run else "live")
+            console.print(status)
+            if data.get("done") or message.get("done"):
+                break
+
+
+class Formatter(RichHelpFormatter):
+    """Rich help formatter with defaults shown."""
+
+    def __init__(
+        self, *args: Any, **kwargs: Any
+    ) -> None:  # pragma: no cover - simple wrapper
+        super().__init__(*args, **kwargs)
+
+    def _get_help_string(
+        self, action: argparse.Action
+    ) -> str:  # pragma: no cover - delegate
+        return argparse.ArgumentDefaultsHelpFormatter._get_help_string(self, action)
+
+
+if __name__ == "__main__":
+    formatter = Formatter
+    parser = argparse.ArgumentParser(
+        description="Control the computer with Pollinations AI",
+        formatter_class=formatter,
+        epilog="Example: python computer_control.py 'Open docs.new and write a poem praising Codex.'",
+    )
+    parser.add_argument("goal", help="Goal to send to the AI")
+    parser.add_argument(
+        "--steps",
+        default="auto",
+        help="Number of loops or 'auto' to run until done",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=15,
+        help="Maximum steps when --steps=auto",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print actions instead of executing"
+    )
+    args = parser.parse_args()
+    steps = None if str(args.steps).lower() == "auto" else int(args.steps)
+    main(args.goal, steps=steps, max_steps=args.max_steps, dry_run=args.dry_run)

--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,84 @@
+"""Platform-independent actions executed on behalf of the AI."""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import subprocess
+import sys
+import shutil
+
+
+try:
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully
+    pyautogui = None  # type: ignore
+
+
+class GUIUnavailable(RuntimeError):
+    """Raised when GUI actions are requested but unavailable."""
+
+
+def ensure_gui_available() -> None:
+    if pyautogui is None:
+        raise GUIUnavailable("pyautogui is not available or no GUI environment")
+
+
+def run_shell(command: str) -> None:
+    """Run a shell command on any platform."""
+    subprocess.run(command, shell=True, check=True)
+
+
+def move_mouse(x: int, y: int) -> None:
+    ensure_gui_available()
+    pyautogui.moveTo(x, y)
+
+
+def click(x: int, y: int, button: str = "left") -> None:
+    ensure_gui_available()
+    pyautogui.click(x=x, y=y, button=button)
+
+
+def write_text(text: str) -> None:
+    ensure_gui_available()
+    pyautogui.write(text)
+
+
+def press_key(key: str) -> None:
+    ensure_gui_available()
+    pyautogui.press(key)
+
+
+def open_app(name: str) -> None:
+    """Open an application by name on the current platform."""
+    try:
+        if os.name == "nt":
+            os.startfile(name)
+        elif sys.platform == "darwin":
+            subprocess.run(["open", "-a", name], check=True)
+        else:
+            if not shutil.which(name):  # ensure the app exists
+                raise FileNotFoundError(name)
+            subprocess.Popen([name])
+    except Exception as exc:  # pragma: no cover - platform dependent
+        raise RuntimeError(f"Failed to open application '{name}': {exc}") from exc
+
+
+def create_file(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def capture_screen() -> str:
+    ensure_gui_available()
+    try:
+        image = pyautogui.screenshot()
+    except Exception as exc:  # pragma: no cover - GUI may be unavailable
+        raise GUIUnavailable(f"Failed to capture screen: {exc}") from exc
+
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    data = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/png;base64,{data}"

--- a/pollinations_client.py
+++ b/pollinations_client.py
@@ -1,0 +1,194 @@
+"""Client utilities for interacting with the Pollinations API."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+import requests
+
+import controller
+
+POLLINATIONS_API = os.environ.get(
+    "POLLINATIONS_API", "https://text.pollinations.ai/openai"
+)
+POLLINATIONS_REFERRER = os.environ.get("POLLINATIONS_REFERRER", "https://example.com")
+
+SYSTEM_PROMPT = (
+    "You control the user's computer via function calls. "
+    "Respond with tool_calls describing actions to reach the objective."
+)
+
+FUNCTIONS_SPEC: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "run_shell",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "move_mouse",
+            "description": "Move the mouse to x,y screen coordinates",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}},
+                "required": ["x", "y"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "click",
+            "description": "Click the mouse at x,y",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                    "button": {
+                        "type": "string",
+                        "enum": ["left", "right", "middle"],
+                        "default": "left",
+                    },
+                },
+                "required": ["x", "y"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_text",
+            "description": "Type text at the keyboard",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "press_key",
+            "description": "Press a keyboard key",
+            "parameters": {
+                "type": "object",
+                "properties": {"key": {"type": "string"}},
+                "required": ["key"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "open_app",
+            "description": "Open an application by name",
+            "parameters": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_file",
+            "description": "Create a file with the given content",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+            },
+        },
+    },
+]
+
+ACTION_MAP: Dict[str, Callable[..., None]] = {
+    "run_shell": controller.run_shell,
+    "move_mouse": controller.move_mouse,
+    "click": controller.click,
+    "write_text": controller.write_text,
+    "press_key": controller.press_key,
+    "open_app": controller.open_app,
+    "create_file": controller.create_file,
+}
+
+
+def query_pollinations(
+    messages: List[Dict[str, Any]], retries: int = 3
+) -> Dict[str, Any]:
+    """Send ``messages`` to Pollinations and return the JSON response."""
+
+    payload = {
+        "model": "openai",
+        "messages": messages,
+        "tools": FUNCTIONS_SPEC,
+        "tool_choice": "auto",
+    }
+
+    headers = {"Referer": POLLINATIONS_REFERRER}
+    delay = 1
+    for attempt in range(1, retries + 1):
+        try:
+            response = requests.post(
+                POLLINATIONS_API, json=payload, headers=headers, timeout=60
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as exc:  # network issues or HTTP errors
+            if attempt == retries:
+                raise RuntimeError("Failed to contact Pollinations API") from exc
+            time.sleep(delay)
+            delay *= 2
+
+    # should never reach here
+    raise RuntimeError("Failed to contact Pollinations API")
+
+
+from rich.console import Console
+from rich.panel import Panel
+
+
+def execute_tool_calls(
+    tool_calls: List[Dict[str, Any]],
+    dry_run: bool = False,
+    console: Optional[Console] = None,
+) -> None:
+    """Run the tool calls returned by the model."""
+    console = console or Console()
+    for call in tool_calls:
+        name = call.get("function", {}).get("name")
+        if not name:
+            continue
+        func = ACTION_MAP.get(name)
+        if not func:
+            continue
+        args = call.get("function", {}).get("arguments", "{}")
+        try:
+            params = json.loads(args) if args else {}
+        except json.JSONDecodeError:
+            console.print(f"[red]Invalid arguments for {name}: {args}[/red]")
+            continue
+        if dry_run:
+            console.print(f"[yellow][DRY-RUN][/yellow] {name}({params})")
+            continue
+        try:
+            func(**params)
+        except Exception as exc:  # pylint: disable=broad-except
+            console.print(Panel(str(exc), title=f"Error executing {name}", style="red"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+requests>=2.31
+pyautogui>=0.9
+pytest>=8.0
+rich>=13.7
+rich-argparse>=1.4
+pillow>=11.0
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,169 @@
+import os
+import sys
+import json
+import shutil
+from typing import Dict, List, Any
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+import pollinations_client as client
+import controller
+
+
+def test_functions_spec_matches_action_map():
+    names_spec = {f["function"]["name"] for f in client.FUNCTIONS_SPEC}
+    names_map = set(client.ACTION_MAP)
+    assert names_spec == names_map
+
+
+def test_execute_tool_calls_dry_run(capsys):
+    calls = [
+        {
+            "function": {
+                "name": "run_shell",
+                "arguments": json.dumps({"command": "echo hello"}),
+            }
+        },
+        {
+            "function": {
+                "name": "open_app",
+                "arguments": json.dumps({"name": "calculator"}),
+            }
+        },
+    ]
+    client.execute_tool_calls(calls, dry_run=True)
+    captured = capsys.readouterr()
+    assert "DRY-RUN" in captured.out
+
+
+def test_help_runs(tmp_path):
+    """computer_control.py --help should exit cleanly."""
+    from subprocess import run
+
+    result = run(
+        [sys.executable, "computer_control.py", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "usage:" in result.stdout.lower()
+
+
+def test_open_app_failure(monkeypatch):
+    def fake_startfile(_):
+        raise FileNotFoundError("missing")
+
+    def fake_which(_):
+        return None
+
+    monkeypatch.setattr("os.startfile", fake_startfile, raising=False)
+    monkeypatch.setattr("shutil.which", fake_which)
+    with pytest.raises(RuntimeError):
+        import controller
+
+        controller.open_app("missing_app")
+
+
+def test_open_app_linux(monkeypatch):
+    import controller
+
+    called = {}
+
+    monkeypatch.setattr(controller, "os", type("DummyOS", (), {"name": "posix"}))
+
+    def fake_which(name):
+        called["which"] = name
+        return "/usr/bin/" + name
+
+    def fake_popen(cmd):
+        called["cmd"] = cmd
+
+        class Dummy:
+            pass
+
+        return Dummy()
+
+    monkeypatch.setattr("shutil.which", fake_which)
+    monkeypatch.setattr(controller.subprocess, "Popen", fake_popen)
+    controller.open_app("vim")
+    assert called["which"] == "vim"
+    assert called["cmd"] == ["vim"]
+
+
+def test_capture_screen_error(monkeypatch):
+    import controller
+
+    def bad_screenshot():
+        raise OSError("scrot missing")
+
+    monkeypatch.setattr(
+        controller,
+        "pyautogui",
+        type("Dummy", (), {"screenshot": staticmethod(bad_screenshot)}),
+    )
+
+    with pytest.raises(controller.GUIUnavailable):
+        controller.capture_screen()
+
+
+def test_query_pollinations_payload(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=60):
+        captured["url"] = url
+        captured["json"] = json
+
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": []}
+
+        return Response()
+
+    monkeypatch.setattr(client.requests, "post", fake_post)
+    messages: List[Dict[str, str]] = [{"role": "user", "content": "hello"}]
+    client.query_pollinations(messages)
+
+    assert captured["json"]["model"] == "openai"
+    assert captured["json"]["messages"] == messages
+    assert captured["json"]["tools"] == client.FUNCTIONS_SPEC
+
+
+def test_query_pollinations_network_error(monkeypatch):
+    def fake_post(*_, **__):
+        raise client.requests.RequestException("boom")
+
+    monkeypatch.setattr(client.requests, "post", fake_post)
+    monkeypatch.setattr(client.time, "sleep", lambda *_: None)
+    messages = [{"role": "user", "content": "hi"}]
+    with pytest.raises(RuntimeError):
+        client.query_pollinations(messages, retries=2)
+
+
+def test_main_uses_blank_image(monkeypatch):
+    import computer_control
+
+    def fake_capture():
+        raise controller.GUIUnavailable("no gui")
+
+    def fake_query(messages: List[Dict[str, Any]]):
+        nonlocal payload
+        payload = messages[1]["content"][1]["image_url"]["url"]
+        return {"choices": [{}]}
+
+    payload = ""
+    monkeypatch.setattr(controller, "capture_screen", fake_capture)
+    monkeypatch.setattr(client, "execute_tool_calls", lambda *_, **__: None)
+    monkeypatch.setattr(client, "query_pollinations", fake_query)
+    computer_control.main("hello", steps=1, dry_run=True)
+    assert payload.startswith("data:image/png;base64,")
+
+
+def test_create_file(tmp_path):
+    path = tmp_path / "sub" / "note.txt"
+    controller.create_file(str(path), "hello")
+    assert path.read_text() == "hello"


### PR DESCRIPTION
## Summary
- add `computer_control.py` demonstrating how to call Pollinations AI and run the resulting command
- document usage and requirements in README
- add simple `requirements.txt`
- note optional test step in quick start

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f74546c84832aa22cfa9306910cad