### PR TITLE
fix(controller): compress screenshots to jpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ python computer_control.py "open calculator"
 
 The program automatically loops until the AI reports it is done (up to a
 maximum of 15 steps by default). Use `--max-steps` to override that limit or
-`--steps N` to force an exact number of iterations.
+`--steps N` to force an exact number of iterations. The `--history` flag
+controls how many of the most recent messages are sent to the API each loop,
+which helps avoid HTTP 413 errors from oversized requests.
 
 
 `computer_control.py` lives in the project root, so run it there or provide the
@@ -75,8 +77,8 @@ confirm each action before it runs.
 Add `--dry-run` to print actions instead of executing them. Pollinations will
 respond with JSON tool calls which are executed sequentially. Each iteration
 captures a fresh screenshot so the AI can correct itself. If a GUI isn't
-available (for example, on a headless server), the script falls back to a blank
-image in dry‑run mode.
+available (for example, on a headless server), the script now falls back to a
+blank image so execution can continue.
 
 
 Supported actions include launching apps, running shell commands, moving and
@@ -91,7 +93,8 @@ codebase and provide suggestions.
 
 
 During execution a small popup window displays a progress bar and the current
-action. If a GUI is unavailable the script falls back to simple console output.
+action. When the number of steps isn't specified the bar runs in indeterminate
+mode. If a GUI is unavailable the script falls back to simple console output.
 
 ## Testing
 

--- a/controller.py
+++ b/controller.py
@@ -1,7 +1,5 @@
 """Platform-independent actions executed on behalf of the AI."""
 
-
-
 from __future__ import annotations
 
 import base64
@@ -11,7 +9,6 @@ import subprocess
 import sys
 import shutil
 from typing import List, Dict, Sequence
-
 
 
 try:
@@ -29,8 +26,7 @@ def ensure_gui_available() -> None:
 
         raise GUIUnavailable(
             "pyautogui is not available or no GUI environment"
-        )
-
+        )  # noqa: E501
 
 
 def run_shell(command: str) -> None:
@@ -48,12 +44,10 @@ def click(x: int, y: int, button: str = "left") -> None:
     pyautogui.click(x=x, y=y, button=button)
 
 
-
 def double_click(x: int, y: int, button: str = "left") -> None:
     """Double-click the mouse at x,y."""
     ensure_gui_available()
     pyautogui.doubleClick(x=x, y=y, button=button)
-
 
 
 def write_text(text: str) -> None:
@@ -64,7 +58,6 @@ def write_text(text: str) -> None:
 def press_key(key: str) -> None:
     ensure_gui_available()
     pyautogui.press(key)
-
 
 
 def scroll(amount: int) -> None:
@@ -108,18 +101,15 @@ def open_app(name: str) -> None:
                 raise FileNotFoundError(name)
             subprocess.Popen([name])
     except Exception as exc:  # pragma: no cover - platform dependent
-
         raise RuntimeError(
             f"Failed to open application '{name}': {exc}"
-        ) from exc
-
+        ) from exc  # noqa: E501
 
 
 def create_file(path: str, content: str) -> None:
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         f.write(content)
-
 
 
 def copy_file(src: str, dst: str) -> None:
@@ -170,7 +160,8 @@ def capture_screen() -> str:
     except Exception:
         pass
     buf = io.BytesIO()
-    image.save(buf, format="PNG", optimize=True)
+    # Compress to JPEG to keep requests small
+    image.save(buf, format="JPEG", quality=70, optimize=True)
 
     data = base64.b64encode(buf.getvalue()).decode()
-    return f"data:image/png;base64,{data}"
+    return f"data:image/jpeg;base64,{data}"


### PR DESCRIPTION
## Context
The program hit HTTP 413 errors due to large image payloads. Progress bar and history handling were already improved, but screenshots were still saved as PNGs which produced sizable requests.

## Solution
- Compress screenshots as JPEG before encoding
- Removed unused variable in `computer_control.py`
- Added a regression test for the JPEG screenshot path
- Adjusted test imports and formatted lines to satisfy `flake8`

## Verification
- `pytest --maxfail=1 --disable-warnings -q`
- `flake8 computer_control.py controller.py tests/test_client.py`


------
https://chatgpt.com/codex/tasks/task_e_684607a5e1e4832a936160983a56b410