### PR TITLE
fix(client): preserve tool call context

### DIFF
--- a/computer_control.py
+++ b/computer_control.py
@@ -78,6 +78,23 @@ def blank_image() -> str:
     return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 
+def trim_history(msgs: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
+    """Return the most recent ``limit`` messages starting from a user or system
+    message.
+
+    This avoids sending an assistant message with ``tool_calls`` without the
+    accompanying tool responses which can trigger API errors.
+    """
+
+    if len(msgs) <= limit:
+        return msgs
+
+    start = len(msgs) - limit
+    while start > 0 and msgs[start]["role"] not in ("system", "user"):
+        start -= 1
+    return msgs[start:]
+
+
 def main(
     goal: str,
     steps: Optional[int] = None,
@@ -88,9 +105,9 @@ def main(
 ) -> None:
     """Send ``goal`` to Pollinations and execute returned actions.
 
-    ``history`` controls how many of the most recent messages are sent to
-    the API each loop.  Limiting the history prevents request payloads from
-    growing too large and triggering HTTP 413 errors.
+    ``history`` controls how many of the most recent messages are sent to the API
+    each loop. Limiting the history prevents request payloads from growing too
+    large and triggering HTTP 413 errors.
     """
     ui = PopupUI(steps)
     print("AI is taking control. Do not touch your computer.")
@@ -117,8 +134,9 @@ def main(
     loop_limit = steps if steps is not None else max_steps
     unlimited = steps is None and loop_limit <= 0
     i = 0
+
     while True:
-        data = client.query_pollinations(messages[-history:])
+        data = client.query_pollinations(trim_history(messages, history))
         choice = data.get("choices", [{}])[0]
         message = choice.get("message", {})
         tool_calls = message.get("tool_calls")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -366,3 +366,24 @@ def test_main_unlimited(monkeypatch):
     )
     computer_control.main("hi", max_steps=0, dry_run=True)
     assert idx["i"] == 2
+
+
+def test_trim_history_avoids_partial_pairs():
+    from computer_control import trim_history  # noqa: E402
+
+    # Build a message sequence with two tool call loops
+    msgs = [
+        {"role": "system", "content": "hi"},
+        {"role": "user", "content": "goal"},
+        {"role": "assistant", "tool_calls": [{"id": "1"}]},
+        {"role": "tool", "tool_call_id": "1", "content": "ok"},
+        {"role": "user", "content": "s1"},
+        {"role": "assistant", "tool_calls": [{"id": "2"}]},
+        {"role": "tool", "tool_call_id": "2", "content": "ok"},
+        {"role": "user", "content": "s2"},
+    ]
+
+    trimmed = trim_history(msgs, 3)
+    assert trimmed[0]["role"] == "user"
+    assert trimmed[1]["role"] == "assistant"
+    assert trimmed[2]["role"] == "tool"


### PR DESCRIPTION
## Context
Pollinations API error occurs when an assistant message containing `tool_calls` is not followed by the tool responses. Messages were truncated arbitrarily causing this invalid sequence.

## Solution
Added `trim_history` helper to ensure history slicing always starts at a user or system message so tool call and response pairs are preserved. Test added for this logic.

## Verification
- `pytest --maxfail=1 --disable-warnings -q`
- `flake8 .`
- `pyright` *(fails: optional member access warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68461f72e1a4832ab8c29d618dbb3728