### PR TITLE
fix(history): avoid invalid tool call trimming

### DIFF
--- a/computer_control.py
+++ b/computer_control.py
@@ -78,11 +78,9 @@ def blank_image() -> str:
     return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 
-
 def trim_history(
     msgs: List[Dict[str, Any]], limit: int
 ) -> List[Dict[str, Any]]:  # noqa: E501
-
     """Return the most recent ``limit`` messages starting from a user or system
     message.
 
@@ -96,7 +94,10 @@ def trim_history(
     start = len(msgs) - limit
     while start > 0 and msgs[start]["role"] not in ("system", "user"):
         start -= 1
-    return msgs[start:]
+    trimmed = msgs[start:]
+    while trimmed and trimmed[-1].get("tool_calls"):
+        trimmed = trimmed[:-1]
+    return trimmed
 
 
 def main(

--- a/pollinations_client.py
+++ b/pollinations_client.py
@@ -435,7 +435,11 @@ def execute_tool_calls(
         except json.JSONDecodeError:
             print(f"Invalid arguments for {name}: {args}")
             results.append(
-                {"role": "tool", "tool_call_id": call_id, "content": "error: bad args"}
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": "error: bad args",
+                }
             )
             continue
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -392,3 +392,19 @@ def test_trim_history_avoids_partial_pairs():
     assert trimmed[0]["role"] == "user"
     assert trimmed[1]["role"] == "assistant"
     assert trimmed[2]["role"] == "tool"
+
+
+def test_trim_history_drops_trailing_tool_call():
+    from computer_control import trim_history  # noqa: E402
+
+    msgs = [
+        {"role": "system", "content": "hi"},
+        {"role": "user", "content": "goal"},
+        {"role": "assistant", "tool_calls": [{"id": "1"}]},
+        {"role": "tool", "tool_call_id": "1", "content": "ok"},
+        {"role": "user", "content": "s1"},
+        {"role": "assistant", "tool_calls": [{"id": "2"}]},
+    ]
+
+    trimmed = trim_history(msgs, 5)
+    assert trimmed[-1]["role"] == "user"


### PR DESCRIPTION
## Context
Runtime error occurred when the history trimming logic left an assistant message with `tool_calls` without its tool responses. This produced 400 errors from the Pollinations API. Lint also reported issues.

## Solution
- Updated `trim_history` to drop any trailing assistant messages that contain `tool_calls` to guarantee complete tool call pairs.
- Broke a long line in `pollinations_client.py` for flake8 compliance.
- Added regression test `test_trim_history_drops_trailing_tool_call`.
- Minor whitespace fixes.

## Verification
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`
- `pyright` *(produces some expected errors due to dynamic usage)*

------
https://chatgpt.com/codex/tasks/task_e_6846edc0f8d4832ab0b8aba2871ff9bd