### PR TITLE
feat(controller): add file and url actions

### DIFF
--- a/computer_control/client.py
+++ b/computer_control/client.py
@@ -221,6 +221,21 @@ FUNCTIONS_SPEC: List[Dict[str, Any]] = [
     {
         "type": "function",
         "function": {
+            "name": "move_file",
+            "description": "Move or rename a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "src": {"type": "string"},
+                    "dst": {"type": "string"},
+                },
+                "required": ["src", "dst"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "delete_file",
             "description": "Delete a file",
             "parameters": {
@@ -269,6 +284,18 @@ FUNCTIONS_SPEC: List[Dict[str, Any]] = [
                     },
                 },
                 "required": ["keys"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "open_url",
+            "description": "Open a URL in the default browser",
+            "parameters": {
+                "type": "object",
+                "properties": {"url": {"type": "string"}},
+                "required": ["url"],
             },
         },
     },
@@ -327,10 +354,12 @@ ACTION_MAP: Dict[str, Callable[..., None]] = {
     "open_app": controller.open_app,
     "create_file": controller.create_file,
     "copy_file": controller.copy_file,
+    "move_file": controller.move_file,
     "delete_file": controller.delete_file,
     "key_down": controller.key_down,
     "key_up": controller.key_up,
     "hotkey": controller.hotkey,
+    "open_url": controller.open_url,
     "list_python_files": analysis.list_python_files,
     "read_file": analysis.read_file,
     "search_code": analysis.search_code,

--- a/computer_control/controller.py
+++ b/computer_control/controller.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import shutil
 import tempfile
+import webbrowser
 from typing import List, Dict, Sequence
 from PIL import Image, ImageGrab, UnidentifiedImageError
 
@@ -119,6 +120,12 @@ def copy_file(src: str, dst: str) -> None:
     shutil.copy(src, dst)
 
 
+def move_file(src: str, dst: str) -> None:
+    """Move or rename a file."""
+    os.makedirs(os.path.dirname(os.path.abspath(dst)), exist_ok=True)
+    shutil.move(src, dst)
+
+
 def delete_file(path: str) -> None:
     """Delete a file if it exists."""
     try:
@@ -143,6 +150,11 @@ def hotkey(keys: Sequence[str]) -> None:
     """Press a combination of keys."""
     ensure_gui_available()
     pyautogui.hotkey(*keys)
+
+
+def open_url(url: str) -> None:
+    """Open a URL in the default web browser."""
+    webbrowser.open(url)
 
 
 def _fallback_screenshot() -> Image | None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -76,6 +76,18 @@ def test_execute_tool_calls_dry_run(capsys):
                 "arguments": json.dumps({"src": "a.txt", "dst": "b.txt"}),
             },
         },
+        {
+            "function": {
+                "name": "move_file",
+                "arguments": json.dumps({"src": "a.txt", "dst": "c.txt"}),
+            },
+        },
+        {
+            "function": {
+                "name": "open_url",
+                "arguments": json.dumps({"url": "https://example.com"}),
+            },
+        },
     ]
     client.execute_tool_calls(calls, dry_run=True, secure=False)
 
@@ -323,6 +335,26 @@ def test_copy_and_delete_file(tmp_path):
     assert dst.read_text() == "hi"
     controller.delete_file(str(src))
     assert not src.exists()
+
+
+def test_move_file(tmp_path):
+    src = tmp_path / "a.txt"
+    dst = tmp_path / "c.txt"
+    src.write_text("hi")
+    controller.move_file(str(src), str(dst))
+    assert dst.read_text() == "hi"
+    assert not src.exists()
+
+
+def test_open_url(monkeypatch):
+    called = {}
+
+    def fake_open(url):
+        called["url"] = url
+
+    monkeypatch.setattr(controller.webbrowser, "open", fake_open)
+    controller.open_url("https://example.com")
+    assert called["url"] == "https://example.com"
 
 
 def test_analysis_functions():


### PR DESCRIPTION
## Context
The controller allowed basic file operations but lacked utilities for moving files or opening URLs. Function definitions and tests were also missing for these actions.

## Solution
- Added `move_file` and `open_url` functions in `controller.py`.
- Extended `FUNCTIONS_SPEC` and `ACTION_MAP` with corresponding entries.
- Updated tests to exercise the new functionality and ensure dry-run execution recognizes them.

## Verification
- `pytest --maxfail=1 --disable-warnings -q`
- `flake8 .`
- `pyright` *(fails: 28 errors)*


------
https://chatgpt.com/codex/tasks/task_e_6848dbc730f4832a8c8cd5481a9551db