### PR TITLE
fix(controller): handle invalid screenshot

### DIFF
--- a/computer_control/controller.py
+++ b/computer_control/controller.py
@@ -179,6 +179,14 @@ def _fallback_screenshot() -> Image | None:
         return None
 
 
+def _blank_data_url() -> str:
+    """Return a 1x1 white PNG data URL."""
+    buf = io.BytesIO()
+    Image.new("RGB", (1, 1), color="white").save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:image/png;base64,{b64}"
+
+
 def capture_screen() -> str:
     ensure_gui_available()
 
@@ -188,9 +196,9 @@ def capture_screen() -> str:
     except Exception as exc:
         image = _fallback_screenshot()
         if image is None:
-            msg = "Failed to capture screen"
             if isinstance(exc, UnidentifiedImageError):
-                msg += ": cannot identify image file"
+                return _blank_data_url()
+            msg = "Failed to capture screen"
             raise GUIUnavailable(msg) from exc
 
     try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -224,6 +224,31 @@ def test_capture_screen_fallback(monkeypatch):
     assert url.startswith("data:image/jpeg;base64,")
 
 
+def test_capture_screen_unidentified(monkeypatch):
+    from computer_control import controller
+    from PIL import UnidentifiedImageError
+
+    def bad_screenshot():
+        raise UnidentifiedImageError("bad")
+
+    def grab():
+        raise OSError("fail")
+
+    monkeypatch.setattr(
+        controller,
+        "pyautogui",
+        type("Dummy", (), {"screenshot": staticmethod(bad_screenshot)}),
+    )
+    monkeypatch.setattr(
+        controller,
+        "ImageGrab",
+        type("Dummy", (), {"grab": staticmethod(grab)}),
+    )
+
+    url = controller.capture_screen()
+    assert url.startswith("data:image/png;base64,")
+
+
 def test_query_pollinations_payload(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Context
macOS users reported crashes when `pyautogui.screenshot()` returned an unreadable temporary file, raising `UnidentifiedImageError`. The program aborted before `main()` could fall back to a blank image.

## Solution
Added a helper that returns a 1x1 PNG data URL and updated `capture_screen()` to use it when screenshot creation fails with `UnidentifiedImageError`. A new test verifies this behavior.

## Verification
- `black computer_control/controller.py tests/test_client.py -q`
- `flake8 .`
- `pyright` *(fails: see log)*
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_684a249c2294832a84e9c50bd3c525ad