### PR TITLE
fix(main): initialize tool_messages

### DIFF
--- a/computer_control/main.py
+++ b/computer_control/main.py
@@ -209,6 +209,7 @@ def main(
         choice = data.get("choices", [{}])[0]
         message = choice.get("message", {})
         tool_calls = message.get("tool_calls")
+        tool_messages: List[Dict[str, Any]] = []
         if tool_calls:
             tool_messages = client.execute_tool_calls(
                 tool_calls, dry_run=dry_run, secure=secure, delay=delay


### PR DESCRIPTION
## Context
Pyright flagged `tool_messages` as possibly unbound in `main.py`. Initializing
this variable ensures it always exists regardless of whether tool calls are
present.

## Solution
Added an initialization of `tool_messages` to an empty list before potential
assignment from `execute_tool_calls`.

## Verification
- `pytest --maxfail=1 --disable-warnings -q`
- `flake8 .`
- `pyright computer_control/main.py` (shows only unrelated optional warnings)


------
https://chatgpt.com/codex/tasks/task_e_6854a0a80264832abfd451d0bb26a12b