### PR TITLE
fix(controller): fallback to blank image when screenshot fails

### DIFF
--- a/computer_control/controller.py
+++ b/computer_control/controller.py
@@ -11,7 +11,7 @@ import shutil
 import tempfile
 import webbrowser
 from typing import List, Dict, Sequence
-from PIL import Image, ImageGrab, UnidentifiedImageError
+from PIL import Image, ImageGrab
 
 
 try:
@@ -193,13 +193,10 @@ def capture_screen() -> str:
     try:
         image = pyautogui.screenshot()
 
-    except Exception as exc:
+    except Exception:
         image = _fallback_screenshot()
         if image is None:
-            if isinstance(exc, UnidentifiedImageError):
-                return _blank_data_url()
-            msg = "Failed to capture screen"
-            raise GUIUnavailable(msg) from exc
+            return _blank_data_url()
 
     try:
         max_dim = max(image.size)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,8 +180,8 @@ def test_capture_screen_error(monkeypatch):
         type("Dummy", (), {"screenshot": staticmethod(bad_screenshot)}),
     )
 
-    with pytest.raises(controller.GUIUnavailable):
-        controller.capture_screen()
+    url = controller.capture_screen()
+    assert url.startswith("data:image/png;base64,")
 
 
 def test_capture_screen_jpeg(monkeypatch):


### PR DESCRIPTION
## Context
User reported `controller.capture_screen` raising `GUIUnavailable` when `pyautogui.screenshot` fails on macOS. The old behaviour aborted execution instead of returning a placeholder image.

## Solution
Updated `capture_screen` to return a 1x1 PNG data URL whenever screenshot capture and fallback methods fail. Tests adjusted accordingly.

## Verification
- `pytest --maxfail=1 --disable-warnings -q`
- `flake8 .`
- `pyright` *(fails: 22 errors pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_685553e8dfc8832aaf12723e4445c90c