### PR TITLE
fix(main): handle incomplete tool call history

### DIFF
--- a/computer_control/main.py
+++ b/computer_control/main.py
@@ -104,44 +104,49 @@ def trim_history(
         start += 1
     trimmed = msgs[start:]
 
-    # drop trailing assistant messages that contain tool_calls
-    while trimmed and trimmed[-1].get("tool_calls"):
-        trimmed.pop()
+    def clean(seq: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Remove invalid assistant/tool pairs from ``seq``."""
 
-    # drop leading tool messages without a preceding assistant
-    while trimmed and trimmed[0]["role"] == "tool":
-        trimmed.pop(0)
+        # drop trailing assistant messages that contain tool_calls
+        while seq and seq[-1].get("tool_calls"):
+            seq.pop()
 
-    # remove any assistant message whose tool_calls have missing responses
-    while True:
-        pending: List[str] = []
-        first_incomplete: Optional[int] = None
-        for i, msg in enumerate(trimmed):
-            if msg.get("tool_calls"):
-                ids = [call.get("id", "") for call in msg["tool_calls"]]
-                pending.extend(ids)
-                if first_incomplete is None:
-                    first_incomplete = i
-            elif msg.get("tool_call_id") and msg["tool_call_id"] in pending:
-                pending.remove(msg["tool_call_id"])
-                if not pending:
-                    first_incomplete = None
+        # drop leading tool messages without a preceding assistant
+        while seq and seq[0]["role"] == "tool":
+            seq.pop(0)
 
-        if not pending:
-            break
+        # remove any assistant message whose tool_calls lack responses
+        while True:
+            pending: List[str] = []
+            first_incomplete: Optional[int] = None
+            for i, msg in enumerate(seq):
+                if msg.get("tool_calls"):
+                    ids = [c.get("id", "") for c in msg["tool_calls"]]
+                    pending.extend(ids)
+                    if first_incomplete is None:
+                        first_incomplete = i
+                else:
+                    call_id = msg.get("tool_call_id")
+                    if call_id and call_id in pending:
+                        pending.remove(call_id)
+                        if not pending:
+                            first_incomplete = None
 
-        # fmt: off
-        assert first_incomplete is not None
-        trimmed = trimmed[first_incomplete + 1:]
-        # fmt: on
-        while trimmed and trimmed[0]["role"] == "tool":
-            trimmed.pop(0)
+            if not pending:
+                break
 
-    # enforce the limit strictly
+            assert first_incomplete is not None
+            seq = seq[first_incomplete + 1 :]  # noqa: E203
+            while seq and seq[0]["role"] == "tool":
+                seq.pop(0)
+
+        return seq
+
+    trimmed = clean(trimmed)
+
     if len(trimmed) > limit:
         trimmed = trimmed[-limit:]
-        while trimmed and trimmed[0]["role"] == "tool":
-            trimmed.pop(0)
+        trimmed = clean(trimmed)
 
     return trimmed
 


### PR DESCRIPTION
## Context
Running `computer_control.py` could produce a 400 error from the Pollinations API when the sent message history ended with an assistant message containing `tool_calls` but without matching tool responses. The trimming logic did not fully re-validate message pairs after enforcing the history limit.

## Solution
- Refactored `trim_history` to include a `clean` helper that removes any incomplete assistant/tool pairs both before and after enforcing the history limit.
- Added safeguard comments and retained Black formatting.

## Verification
- `pytest --maxfail=1 --disable-warnings -q`
- `flake8 .`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_685dbfedbb68832a9451a5f94a030a90