### PR TITLE
fix(main): validate message history

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -641,3 +641,27 @@ def test_main_retries_on_413(monkeypatch):
 
     cc_main("goal", steps=1, dry_run=True, history=4)
     assert calls["count"] == 2
+
+
+def test_validate_history_ok():
+    from computer_control.main import validate_history
+
+    msgs = [
+        {"role": "system", "content": "hi"},
+        {"role": "assistant", "tool_calls": [{"id": "1"}]},
+        {"role": "tool", "tool_call_id": "1", "content": "ok"},
+    ]
+
+    validate_history(msgs)
+
+
+def test_validate_history_error():
+    from computer_control.main import validate_history
+
+    msgs = [
+        {"role": "assistant", "tool_calls": [{"id": "1"}]},
+        {"role": "user", "content": "next"},
+    ]
+
+    with pytest.raises(ValueError):
+        validate_history(msgs)


### PR DESCRIPTION
## Context
Pollinations returned HTTP 400 errors if the history contained an incomplete pair of tool messages. This could happen if history trimming removed some tool responses.

## Solution
Added a `validate_history` helper to detect unfinished tool calls before each API request. `main` now validates the trimmed message batch so we avoid sending invalid conversations.

## Verification
- `flake8 .`
- `pyright`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_685f000cd20c832aa23b305a36ca82e4